### PR TITLE
Add Datadog Instrumentation to AWS Lambda Function

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -129,8 +129,16 @@ resource "aws_lambda_function" "scheduler_lambda" {
       TIME               = var.time
       RDS_SCHEDULE       = var.rds_schedule
       EC2_SCHEDULE       = var.ec2_schedule
+      DD_ENV             = "<ENVIRONMENT>"
+      DD_SERVICE         = "<SERVICE_NAME>"
+      DD_VERSION         = "<VERSION>"
+      DD_API_KEY         = "<DATADOG_API_KEY>"
     }
   }
+  layers = [
+    "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Python37:110",
+    "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:81"
+  ]
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_to_call_scheduler" {
@@ -140,3 +148,4 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_scheduler" {
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.check-scheduler-event.arn
 }
+


### PR DESCRIPTION
This pull request introduces Datadog instrumentation to the existing AWS Lambda function defined in the Terraform configuration. The changes aim to enhance observability by integrating Datadog's monitoring capabilities, allowing for better tracking of the function's performance and behavior.

## Changes Made
- Added environment variables for Datadog configuration: DD_ENV, DD_SERVICE, DD_VERSION, and DD_API_KEY to the AWS Lambda function.
- Included Datadog Lambda layers for Python and the Datadog Extension to the Lambda function to enable monitoring and tracing.
- These changes will allow the Lambda function to send metrics, logs, and traces to Datadog, improving visibility into its execution and performance.

---
*This PR was generated automatically by the DD Instrumenter Agent*